### PR TITLE
Add support for adding Send bound for methods

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,3 +1,4 @@
+#![allow(incomplete_features)]
 #![feature(generic_associated_types, type_alias_impl_trait)]
 extern crate real_async_trait;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,7 +210,6 @@ fn handle_item_impl(mut item: ItemImpl) -> TokenStream {
         );
         let existential_type_ident = Ident::new(&existential_type_name, Span::call_site());
 
-        let real_async_trait_attributes = parse_attributes(&mut method.attrs);
 
         existential_type_defs.push(ItemType {
             attrs: Vec::new(),
@@ -237,9 +236,6 @@ fn handle_item_impl(mut item: ItemImpl) -> TokenStream {
                         .iter()
                         .cloned()
                         .map(|lifetime_def| TypeParamBound::Lifetime(lifetime_def.lifetime)),
-                ).chain(
-                    real_async_trait_attributes.into_iter()
-                    .map(|attr| TypeParamBound::from(attr))
                 )
                 .collect(),
                 impl_token: Token!(impl)(Span::call_site()),


### PR DESCRIPTION
Hi, I added a method level attribute which adds Send as an additional type bound on the trait's associated type. Here's an example of what it looks like:

 `
#[real_async_trait]
pub trait SendDemo{
    #[real_async_trait(Send)]
    async fn fails_to_compile<'a>(&'a mut self)->();
    async fn non_sendable<'a>(&'a mut self)->();
    #[real_async_trait(Send)]
    async fn sendable<'a>(&'a mut self) -> Result<(),()>;
}

pub struct sendingStruct{}

#[real_async_trait]
impl SendDemo for sendingStruct{
    async fn fails_to_compile<'a>(&'a mut self)->(){
        use std::rc::Rc;
        let test_rc: Rc<u32> = Rc::new(4);
        self.sendable().await;
        return ();
    }

    async fn non_sendable<'a>(&'a mut self) ->(){
        use std::rc::Rc;
        let test_rc: Rc<u32> = Rc::new(4);
        self.sendable().await;
        return ();
    }

    async fn sendable<'a>(&'a mut self) -> Result<(),()> {
        return Ok(())
    }
}
` 
I've never dealt with token trees or parsing before so it's quite hacky and is syntactically a little awkward. But I think the ability to add some additional trait bounds, especially Send, could be quite useful.