### PR TITLE
Allow multiple impls in the same module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,13 +362,11 @@ fn handle_item_impl(mut item: ItemImpl) -> TokenStream {
 
     quote! {
 
-        mod __real_async_trait_impl {
-            use super::*;
-
+        const _: () = {
             #item
 
             #(#existential_type_defs)*
-        }
+        };
     }
 }
 


### PR DESCRIPTION
by using a `const _: () = { … };` "anonymous scope" rather than a module with a hard-coded name.

Fixes #2